### PR TITLE
Add htmlencode to prep text for HTML use

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+const htmlencode = require('htmlencode');
+
 module.exports = (eleventyConfig, options) => {
   const highlighter = eleventyConfig.markdownHighlighter;
   const html_tag = options?.html_tag || 'pre';
@@ -10,7 +12,7 @@ module.exports = (eleventyConfig, options) => {
 
   eleventyConfig.addMarkdownHighlighter((str, language) => {
     if (language === "mermaid") {
-      return `<${html_tag} class="mermaid${extra_classes}">${str}</${html_tag}>`;
+      return `<${html_tag} class="mermaid${extra_classes}">${htmlencode.htmlEncode(str)}</${html_tag}>`;
     }
     if (highlighter) {
       return highlighter(str, language)

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.1"
+  },
+  "dependencies": {
+    "htmlencode": "^0.0.4"
   }
 }


### PR DESCRIPTION
This removes the overhead of the developer (or another plugin?) from having to know to HTML encode the Mermaid diagrams (which make heavy use of `<` and `>`).

I'm using this plugin with a Liquid based site, and while I could attempt to use something like `{{ content | escape }}` that would ultimately mean all inlined HTML would be escaped as well...which isn't what I'm after. Additionally, forcing the Mermaid text into their own `{% capture %}` blocks and then escaping the output (while also possible), seems like extra overhead for the day-to-day use of Mermaid in Liquid (at least) markup.

Consequently, using `htmlencode` here seemed much simpler with less risk. 😄 

Cheers!
🎩 